### PR TITLE
précise que le champ zep n'est pas requis (pour firefox)

### DIFF
--- a/src/CEC/TutoratBundle/Form/Type/LyceeType.php
+++ b/src/CEC/TutoratBundle/Form/Type/LyceeType.php
@@ -39,6 +39,7 @@ class LyceeType extends AbstractType
             ))
             ->add('zep', 'checkbox', array(
                 'label'  => false,
+                'required' => false,
                 'help_inline'    => 'Ce lycée est situé dans une ZEP',
             ));
     }


### PR DESCRIPTION
Je test les pull request ^^

Plus sérieusement firefox ne voulait pas valider le formulaire de création de lycée sans le mettre en zep... Il a du croire que la checkbox voulait dire "j'accepte les termes d'utilisation" ou un truc du genre ^^
